### PR TITLE
task: Update embedded-hal to v1.0.0, change mcp2221 -> mcp2221-hal crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,14 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-embedded-hal = "0.2.6"
-defmt = { version = "0.2.1", optional = true }
-log = { version = "0.4.14", optional = true }
+embedded-hal = "1.0.0"
+defmt = { version = "1.0.1", optional = true }
+log = { version = "0.4.28", optional = true }
+embedded-io = "0.6.1"
 
 [dev-dependencies]
 anyhow = "1.0.38"
-embedded-hal-mock = "0.8.0"
+embedded-hal-mock = "0.11.1"
 mcp2221 = "0.1.0"
 serialport = "4.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ embedded-io = "0.6.1"
 [dev-dependencies]
 anyhow = "1.0.38"
 embedded-hal-mock = "0.11.1"
-mcp2221 = "0.1.0"
+mcp2221-hal = "0.1.0"
 serialport = "4.2.0"
 
 [features]

--- a/examples/read_chip_id.rs
+++ b/examples/read_chip_id.rs
@@ -3,6 +3,7 @@
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
 use anyhow::Result;
+use mcp2221_hal::gpio::GpioChanges;
 use stm32_bootloader_client::{ProtocolVersion, Stm32, Stm32i2c};
 
 fn main() {
@@ -12,19 +13,19 @@ fn main() {
 }
 
 fn run() -> Result<()> {
-    let mut config = mcp2221::Config::default();
-    config.i2c_speed_hz = 400_000;
-    let mut dev = mcp2221::Handle::open_first(&config)?;
+    let mut dev = mcp2221_hal::MCP2221::connect()?;
+    dev.i2c_set_bus_speed(mcp2221_hal::i2c::I2cSpeed::fast_400k())?;
 
     // Set GPIO pin 0 high. This is useful if your I2C bus goes through a level
     // shifter and you need to enable that level shifter in order to use the I2C
     // bus.
-    let mut gpio_config = mcp2221::GpioConfig::default();
-    gpio_config.set_direction(0, mcp2221::Direction::Output);
-    gpio_config.set_value(0, true);
-    dev.configure_gpio(&gpio_config)?;
+    let mut gpio_change = GpioChanges::new();
+    gpio_change
+        .with_gp0_direction(mcp2221_hal::gpio::GpioDirection::Output)
+        .with_gp0_level(mcp2221_hal::gpio::LogicLevel::High);
+    dev.gpio_write(&gpio_change)?;
 
-    dev.check_bus()?;
+    dev.status()?;
 
     // This is the address for I2C1 on the STM32G0 series. See AN2606 for
     // the list of addresses for other parts.

--- a/examples/serialport.rs
+++ b/examples/serialport.rs
@@ -72,8 +72,8 @@ impl BootloaderIO for StmSerial {
     }
 
     /// Get the configured wait time for erase operation
-    fn get_config_erase_wait_ms(&self) -> u32 {
-        100
+    fn get_config_erase_wait_ns(&self) -> u64 {
+        100_000_000
     }
 }
 


### PR DESCRIPTION
Hi!

Sending this PR here as your fork is the most up-to-date, hope that's alright with you.

The PR updates the dependencies, most importantly embedded-hal from 0.2 to 1.0.0.
To have the example `read_chip_id` stay compatible, crate `mcp2221` was replaced with `mcp2221-hal` which is eh1.

DelayMs was transformed to DelayNs, as eh1 dictates.

Further, I followed the recommendation by `embedded-hal`-authors here: https://docs.rs/embedded-hal/latest/embedded_hal/i2c/index.html#for-driver-authors

So the I2c variant does own the device handle now instead of taking a mutable reference..

> Drivers should take the I2c instance as an argument to new(), and store it in their struct. They should not take &mut I2c, the trait has a blanket impl for all &mut T so taking just I2c ensures the user can still pass a &mut, but is not forced to.
>
> Drivers should not try to enable bus sharing by taking &mut I2c at every method. This is much less ergonomic than owning the I2c, which still allows the user to pass an implementation that does sharing behind the scenes (from [embedded-hal-bus](https://docs.rs/embedded-hal-bus), or others).